### PR TITLE
fix(): Setup volume mount to backup resolv.conf

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,6 +194,12 @@ func (s *admissionWebhookServer) createVolumesPatch(p string, volumes []corev1.V
 				},
 			},
 		},
+		corev1.Volume{
+			Name: "nsm-dns-config",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	)
 	return jsonpatch.NewOperation("add", path.Join(p, "spec", "volumes"), volumes)
 }
@@ -273,6 +279,10 @@ func (s *admissionWebhookServer) addVolumeMounts(c *corev1.Container) {
 		Name:      "nsm-socket",
 		MountPath: "/var/lib/networkservicemesh",
 		ReadOnly:  true,
+	}, corev1.VolumeMount{
+		Name:      "nsm-dns-config",
+		MountPath: "/etc/nsm-dns-config",
+		ReadOnly:  false,
 	})
 }
 


### PR DESCRIPTION
Set up an emptydir volume for the cmd-nsc-init and cmd-nsc. The init container backs up the original resolv.conf to the volume and the cmd-nsc sidecar reads from it.

This was needed because istio-proxy that runs as one of the sidecars seems to read the resolv.conf during bootup and cache the config. Any subsequent change to the resolv.conf is not picked up by the proxy. So if the cmd-nsc sidecar takes time to boot up and modify the resolv.conf for all the other containers, the istio-proxy sidecar would have read the original resolv.conf and ignored the config written by cmd-nsc. This causes name resolution to fail in istio-proxy for the domains that are serviced by a custom dns server other than the default kube-dns.

Signed-off-by: Bharath Horatti <bharath@aveshasystems.com>