### PR TITLE
feat(): add namespace exceptions to the webhook

### DIFF
--- a/internal/k8s/selfregister.go
+++ b/internal/k8s/selfregister.go
@@ -131,15 +131,6 @@ func (a *AdmissionWebhookRegisterClient) Register(ctx context.Context, c *config
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
-							Key:      "name",
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values: []string{
-								"spire",
-								"kube-system",
-								"kubeslice-controller",
-							},
-						},
-						{
 							Key:      "kubernetes.io/metadata.name",
 							Operator: metav1.LabelSelectorOpNotIn,
 							Values: []string{

--- a/internal/k8s/selfregister.go
+++ b/internal/k8s/selfregister.go
@@ -128,6 +128,28 @@ func (a *AdmissionWebhookRegisterClient) Register(ctx context.Context, c *config
 						},
 					},
 				},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values: []string{
+								"spire",
+								"kube-system",
+								"kubeslice-controller",
+							},
+						},
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values: []string{
+								"spire",
+								"kube-system",
+								"kubeslice-controller",
+							},
+						},
+					},
+				},
 				SideEffects:             &sideEffects,
 				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &policy,


### PR DESCRIPTION
The nsm webhook applies to all the namespaces. There are no exceptions. This PR will add exceptions for kube-system, kubeslice-controller and spire namespace.

Signed-off-by: Rahul-D78 <rahul.kumar@aveshasystems.com>