### PR TITLE
fix(): Added security ctx for cmd-nsc-init and cmd-nsc

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,6 +230,9 @@ func parseResources(v string, logger *zap.SugaredLogger) map[string]int {
 }
 
 func (s *admissionWebhookServer) createInitContainerPatch(p, v string, initContainers []corev1.Container) jsonpatch.JsonPatchOperation {
+	var runAsNonRoot bool = false
+	var runAsUser int64 = 0
+	var runAsGroup int64 = 0
 	poolResources := parseResources(v, s.logger)
 	for _, img := range s.config.InitContainerImages {
 		initContainers = append(initContainers, corev1.Container{
@@ -237,6 +240,11 @@ func (s *admissionWebhookServer) createInitContainerPatch(p, v string, initConta
 			Env:             append(s.config.GetOrResolveEnvs(), corev1.EnvVar{Name: s.config.NSURLEnvName, Value: v}),
 			Image:           img,
 			ImagePullPolicy: corev1.PullIfNotPresent,
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:    &runAsUser,
+				RunAsGroup:   &runAsGroup,
+				RunAsNonRoot: &runAsNonRoot,
+			},
 		})
 		s.addVolumeMounts(&initContainers[len(initContainers)-1])
 		s.addResources(&initContainers[len(initContainers)-1], poolResources)
@@ -245,12 +253,26 @@ func (s *admissionWebhookServer) createInitContainerPatch(p, v string, initConta
 }
 
 func (s *admissionWebhookServer) createContainerPatch(p, v string, containers []corev1.Container) jsonpatch.JsonPatchOperation {
+	var runAsNonRoot bool = false
+	var runAsUser int64 = 0
+	var runAsGroup int64 = 0
+
+	capabilities := corev1.Capabilities{
+		Add: []corev1.Capability{"NET_ADMIN", "NET_RAW", "NET_BIND_SERVICE"},
+	}
+
 	for _, img := range s.config.ContainerImages {
 		containers = append(containers, corev1.Container{
 			Name:            nameOf(img),
 			Env:             append(s.config.GetOrResolveEnvs(), corev1.EnvVar{Name: s.config.NSURLEnvName, Value: v}),
 			Image:           img,
 			ImagePullPolicy: corev1.PullIfNotPresent,
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &capabilities,
+				RunAsUser:    &runAsUser,
+				RunAsGroup:   &runAsGroup,
+				RunAsNonRoot: &runAsNonRoot,
+			},
 		})
 		s.addVolumeMounts(&containers[len(containers)-1])
 		s.addDefaultResourceRequest(&containers[len(containers)-1])


### PR DESCRIPTION
If the nsc has a security context at the pod level to run as non root, the nsm init container and the sidecar container fails due to lack of permissions. Added appropriate security context to the containers.