### PR TITLE
Support nsc tcp connections and integrate spire csi

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func (s *admissionWebhookServer) createVolumesPatch(p string, volumes []corev1.V
 			Name: "spire-agent-socket",
 			VolumeSource: corev1.VolumeSource{
 				CSI: &corev1.CSIVolumeSource{
-					Driver: "csi.spiffe.io",
+					Driver:   "csi.spiffe.io",
 					ReadOnly: &readOnly,
 				},
 			},

--- a/main.go
+++ b/main.go
@@ -175,13 +175,14 @@ func (s *admissionWebhookServer) postProcessPodMeta(podMetaPtr, metaPtr *v1.Obje
 
 func (s *admissionWebhookServer) createVolumesPatch(p string, volumes []corev1.Volume) jsonpatch.JsonPatchOperation {
 	hostPathDir := corev1.HostPathDirectory
+	readOnly := true
 	volumes = append(volumes,
 		corev1.Volume{
 			Name: "spire-agent-socket",
 			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/run/spire/sockets",
-					Type: &hostPathDir,
+				CSI: &corev1.CSIVolumeSource{
+					Driver: "csi.spiffe.io",
+					ReadOnly: &readOnly,
 				},
 			},
 		},


### PR DESCRIPTION
Need to support nsc connections over tcp to get rid of hostPath dependency needed for unix sockets. Integrate spire csi driver to get rid of hostPath dependency needed for the connection between the nsc and spire-agent.