### PR TITLE
fix(AM-11295):  namespace selector added

### DIFF
--- a/internal/k8s/selfregister.go
+++ b/internal/k8s/selfregister.go
@@ -104,7 +104,15 @@ func (a *AdmissionWebhookRegisterClient) Register(ctx context.Context, c *config
 						},
 					},
 				},
-				SideEffects:             &sideEffects,
+				SideEffects: &sideEffects,
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "kubeslice.io/slice",
+							Operator: metav1.LabelSelectorOpExists,
+						},
+					},
+				},
 				AdmissionReviewVersions: []string{"v1"},
 				FailurePolicy:           &policy,
 				ClientConfig: admissionv1.WebhookClientConfig{


### PR DESCRIPTION
- add `kubeslice.io/slice` namespace selector in webhook configuration 