### PR TITLE
fix(AM-11295):  namespace selector added

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@ dockerImagePipeline(
   dockerfile: 'Dockerfile',
   buildContext: '.',
   buildArguments: [PLATFORM:"amd64"]
+
   
 )

--- a/internal/k8s/selfregister.go
+++ b/internal/k8s/selfregister.go
@@ -139,6 +139,11 @@ func (a *AdmissionWebhookRegisterClient) Register(ctx context.Context, c *config
 								"kubeslice-controller",
 							},
 						},
+						{
+							Key:      "kubeslice.io/inject",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"true"},
+						},
 					},
 				},
 				SideEffects:             &sideEffects,


### PR DESCRIPTION
add `kubeslice.io/slice` namespace selector in webhook configuration 